### PR TITLE
Relax asset header and reference data schemas for cross-asset-class fit

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ownera.io/certificates/data/assetHeader.schema.json",
   "title": "Asset Header",
-  "description": "Core asset catalog/header data describing an asset's identity, category, and available data types",
+  "description": "Core asset catalog/header data describing an asset's identity and on-chain representations. Designed to apply across asset classes (securities, funds, stablecoins, digital commodities, tokenised RWAs).",
   "type": "object",
   "definitions": {
     "caip19": {
@@ -15,11 +15,11 @@
         },
         "assetNamespace": {
           "type": "string",
-          "description": "Asset namespace (e.g. \"erc20\")"
+          "description": "Asset namespace (e.g. \"erc20\", \"slip44\", \"spl\")"
         },
         "assetReference": {
           "type": "string",
-          "description": "Asset reference (e.g. contract address)"
+          "description": "Asset reference (e.g. contract address, slip44 coin type)"
         },
         "itemId": {
           "type": ["string", "null"],
@@ -35,18 +35,20 @@
         "caip19": { "$ref": "#/definitions/caip19" },
         "issuanceMode": {
           "type": "string",
-          "description": "How the asset is represented on-chain (e.g. \"native\", \"wrapped\")"
+          "enum": ["native", "wrapped", "twin"],
+          "description": "How the asset is represented on this chain. \"native\": the token is the asset itself, primary issuance on this chain (e.g. BTC on Bitcoin, USDC on Ethereum, BUIDL where the on-chain token is the legal share record). \"wrapped\": represents the same asset that lives natively on another blockchain, with custody held on-chain in a bridge contract or vault (e.g. WBTC, USDC.e). \"twin\": represents an off-chain real-world asset with custody held off-chain by a depository or transfer agent (e.g. tokenised AAPL shares, tokenised T-bills)."
         }
       },
       "required": ["caip19", "issuanceMode"]
     },
     "additionalIdentifier": {
       "type": "object",
-      "description": "Non-primary asset identifier",
+      "description": "Non-primary asset identifier. Industry-standard identifier types are enumerated to keep downstream consumers consistent.",
       "properties": {
         "type": {
           "type": "string",
-          "description": "Identifier type (e.g. \"DTI\", \"CUSIP\", \"SEDOL\")"
+          "enum": ["ISIN", "CUSIP", "SEDOL", "FIGI", "DTI", "RIC", "BBGID", "WKN", "VALOR"],
+          "description": "Asset-level identifier type. ISIN (ISO 6166), CUSIP, SEDOL, FIGI (OpenFIGI), DTI (ISO 24165), RIC (Refinitiv), BBGID (Bloomberg), WKN (German), VALOR (Swiss). LEI is issuer-level (see referenceData.issuerLEI); CFI/FISN are top-level fields on this header."
         },
         "value": {
           "type": "string",
@@ -63,26 +65,30 @@
     },
     "ticker": {
       "type": "string",
-      "description": "Ticker symbol"
+      "description": "Ticker or trading symbol. Optional — many asset classes (private funds, bonds, pre-issuance tokens) have no ticker."
     },
     "category": {
       "type": "string",
-      "description": "Asset category (e.g. MMF, equity, bond)"
+      "description": "Asset category. Free-form for now; expected vocabulary includes \"Equity\", \"Bond\", \"Fund\", \"MMF\", \"Stablecoin\", \"Digital Commodity\", \"Token\", \"Derivative\", \"Commodity\", \"RealEstate\". For formal classification use the optional `cfi` field (ISO 10962)."
     },
     "description": {
       "type": "string",
       "description": "Human-readable description of the asset"
     },
-    "availableDataTypes": {
-      "type": "array",
-      "description": "Data types available for this asset",
-      "items": { "type": "string" },
-      "minItems": 1
-    },
     "icon": {
       "type": "string",
       "format": "uri",
       "description": "URL to asset icon image"
+    },
+    "currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$",
+      "description": "Denomination currency (ISO 4217). Optional."
+    },
+    "cfi": {
+      "type": "string",
+      "pattern": "^[A-Z]{6}$",
+      "description": "Classification of Financial Instruments code (ISO 10962). Optional structured counterpart to `category`."
     },
     "representations": {
       "type": "array",
@@ -91,9 +97,9 @@
     },
     "additionalIdentifiers": {
       "type": "array",
-      "description": "Additional identifiers (DTI, CUSIP, etc.)",
+      "description": "Identifiers other than the primary one carried in the ingest envelope (ISIN, CUSIP, FIGI, DTI, LEI, etc.)",
       "items": { "$ref": "#/definitions/additionalIdentifier" }
     }
   },
-  "required": ["name", "ticker", "category", "description", "availableDataTypes"]
+  "required": ["name", "category"]
 }

--- a/schemas/data/referenceData.schema.json
+++ b/schemas/data/referenceData.schema.json
@@ -2,31 +2,54 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ownera.io/certificates/data/referenceData.schema.json",
   "title": "Reference Data",
-  "description": "Issuance and reference information about an asset, including issuer details and offering metadata",
+  "description": "Issuance and reference information about an asset. All fields are optional because reference data is heterogeneous across asset classes — for example, native digital commodities (BTC, ETH) have no issuer, jurisdiction, or issuance platform. Producers should populate whatever they can; consumers must handle absence.",
   "type": "object",
   "properties": {
-    "createdAt": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the reference data was created"
-    },
     "issuerName": {
       "type": "string",
-      "description": "Legal name of the asset issuer"
+      "description": "Legal name of the asset issuer. Absent for native digital commodities."
+    },
+    "issuerLEI": {
+      "type": "string",
+      "pattern": "^[A-Z0-9]{18}[0-9]{2}$",
+      "description": "Legal Entity Identifier (ISO 17442). Preferred over issuerName when available."
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date the asset was issued."
+    },
+    "maturityDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Maturity date (for fixed-income instruments)."
+    },
+    "country": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "Country of issuance (ISO 3166-1 alpha-2)."
+    },
+    "issuanceJurisdiction": {
+      "type": "string",
+      "description": "Free-form jurisdiction label, when ISO 3166 country code is not sufficient (e.g. \"British Virgin Islands\", \"Cayman Islands\")."
+    },
+    "issuancePlatform": {
+      "type": "string",
+      "description": "Issuance technology platform, when applicable (e.g. \"Securitize\", \"Tokeny\", \"Circle\"). Not applicable for native digital commodities or traditional securities."
     },
     "offeringPageUrl": {
       "type": "string",
       "format": "uri",
-      "description": "URL to the offering page for the asset"
+      "description": "URL to the offering or product page."
     },
-    "issuancePlatform": {
+    "prospectusUrl": {
       "type": "string",
-      "description": "Platform used for issuance (e.g. Securitize, Tokeny)"
+      "format": "uri",
+      "description": "URL to the prospectus or offering memorandum."
     },
-    "issuanceJurisdiction": {
+    "regulatoryStatus": {
       "type": "string",
-      "description": "Jurisdiction where the asset was issued"
+      "description": "Regulatory status (e.g. \"Reg D\", \"Reg S\", \"UCITS\", \"unregistered\")."
     }
-  },
-  "required": ["createdAt", "issuerName", "issuancePlatform", "issuanceJurisdiction"]
+  }
 }


### PR DESCRIPTION
## Summary

The current required fields are unrepresentative of the asset classes the
catalogue actually carries. In live data on `bank-us-local6`, 5 of 26 ingest
attempts are rejected for "General validation error" — they are exactly BTC,
ETH, XRP, SOL, and USDG. All of them have `issuerName`, `issuancePlatform`,
and `issuanceJurisdiction` as `null` upstream, because for native digital
commodities those concepts are categorically absent. No mapper change can
produce a schema-conformant payload for these — only a schema change can.

This PR loosens required fields, removes a couple of fields that don't
belong, and constrains some enums that were freeform. Goal: a schema that
fits stablecoins, MMFs, tokenised securities, and digital commodities
without forcing producers to invent placeholder values.

## Changes

### `assetHeader`

- **Remove `availableDataTypes`.** Registry/discoverability concern, not
  asset identity. The Catalog already knows which data types arrived for
  an asset by observing ingests.
- **Required reduced to `[name, category]`.** `ticker` and `description`
  become optional — many asset classes (private funds, bonds, pre-issuance
  tokens) have no ticker, and many upstream feeds carry no description.
- **Enum-constrain `additionalIdentifier.type`** to known industry standards:
  `ISIN, CUSIP, SEDOL, FIGI, DTI, RIC, BBGID, WKN, VALOR`. Avoids
  `"isin"` / `"ISIN"` / `"Isin"` divergence downstream. `LEI` is
  issuer-level so it moved to `referenceData.issuerLEI`.
- **Enum-constrain `representation.issuanceMode`** to `[native, wrapped, twin]`
  with definitions:
  - `native` — the token is the asset itself (BTC, USDC, BUIDL where the
    on-chain token is the legal share record).
  - `wrapped` — represents the same asset on another chain, custody on-chain
    in a bridge contract or vault (WBTC, USDC.e).
  - `twin` — represents an off-chain real-world asset, custody off-chain
    (tokenised AAPL, tokenised T-bills).
- **Add optional `currency`** (ISO 4217) and **`cfi`** (ISO 10962, structured
  counterpart to free-form `category`).

### `referenceData`

- **No required fields.** Reference data is heterogeneous across asset
  classes. Producers populate what they have; consumers handle absence.
- **Drop `createdAt`** (ambiguous — record creation? issuance?). Replaced
  with optional `issuanceDate`.
- **Add optional industry fields:** `issuerLEI` (ISO 17442 with format
  pattern), `country` (ISO 3166-1 alpha-2), `maturityDate`, `prospectusUrl`,
  `regulatoryStatus`.

## Migration impact for producers

- **`bridged` → `wrapped`** in `representation.issuanceMode`. The Asset
  Catalog upstream currently emits `"bridged"` for USDC.e; this becomes
  `"wrapped"` under the new taxonomy. One-line producer change.
- Producers no longer need to invent values for fields they don't have —
  null/absent is now schema-valid.

## Test plan

- [ ] Re-run the data-adapter against `bank-us-local6` after Router picks
      up the new schemas; confirm BTC/ETH/XRP/SOL/USDG entries are accepted.
- [ ] Producer-side: confirm Asset Catalog updates `bridged` → `wrapped`.
- [ ] JSON-schema lint passes (existing GH workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)