### PR TITLE
Add rating data schema (multi-agency)

### DIFF
--- a/schemas/data/rating.example.json
+++ b/schemas/data/rating.example.json
@@ -2,7 +2,7 @@
   "timestamp": 1779000000000,
   "values": {
     "mmf": {
-      "grade": "Aaa-mf",
+      "grade": "Aaa",
       "scale": "moodys-mmf",
       "timestamp": 1779000000000
     },

--- a/schemas/data/rating.example.json
+++ b/schemas/data/rating.example.json
@@ -1,26 +1,31 @@
 {
   "timestamp": 1779000000000,
+  "debtId": "ISN:IE0004514711",
+  "otherIdentifiers": [
+    "ISN:IE0005070622",
+    "ISN:IE0004514828",
+    "ISN:IE0032713202",
+    "ISN:IE0030625135"
+  ],
+  "fundName": "BNY Mellon US Dollar Liquidity Fund",
+  "regulatoryDisclosures": "Please see www.moodys.com for the assessment announcement, copyright notice/disclaimer, additional disclosures and other terms and conditions.",
   "values": {
     "mmf": {
-      "grade": "Aaa",
+      "grade": "Aaa-mf",
       "scale": "moodys-mmf",
-      "timestamp": 1779000000000
-    },
-    "longTerm": {
-      "grade": "Aaa",
-      "scale": "moodys-long-term"
-    },
-    "outlook": {
-      "grade": "Stable",
-      "scale": "moodys-outlook"
+      "class": "Backed LT Mutual Fund (Foreign Currency)",
+      "classDescription": "MONEY MARKET FUND",
+      "timestamp": 1305936000000,
+      "action": "Change in Scale",
+      "supportingEntity": "BNY Mellon Investment Adviser, Inc.",
+      "supportTypeDescription": "Mutual Fund Advisor"
     }
   },
   "classification": {
     "securityClass": "Mutual Fund (MMK)",
     "instrumentType": "Money Market Fund",
     "privatePlacement": "Not Applicable",
-    "enhancements": "Acme Asset Management LLC",
-    "equityEvents": "Inception 2015-03-12",
-    "fundName": "XYZ US Dollar Liquidity Fund"
+    "enhancements": "BNY Mellon Investment Adviser, Inc.",
+    "equityEvents": "Mutual Fund Inception Date"
   }
 }

--- a/schemas/data/rating.example.json
+++ b/schemas/data/rating.example.json
@@ -1,0 +1,26 @@
+{
+  "timestamp": 1779000000000,
+  "values": {
+    "mmf": {
+      "grade": "Aaa-mf",
+      "scale": "moodys-mmf",
+      "timestamp": 1779000000000
+    },
+    "longTerm": {
+      "grade": "Aaa",
+      "scale": "moodys-long-term"
+    },
+    "outlook": {
+      "grade": "Stable",
+      "scale": "moodys-outlook"
+    }
+  },
+  "classification": {
+    "securityClass": "Mutual Fund (MMK)",
+    "instrumentType": "Money Market Fund",
+    "privatePlacement": "Not Applicable",
+    "enhancements": "Acme Asset Management LLC",
+    "equityEvents": "Inception 2015-03-12",
+    "fundName": "XYZ US Dollar Liquidity Fund"
+  }
+}

--- a/schemas/data/rating.schema.json
+++ b/schemas/data/rating.schema.json
@@ -2,13 +2,33 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ownera.io/certificates/data/rating.schema.json",
   "title": "Rating",
-  "description": "A snapshot of credit-rating observations for a single asset from a single rating agency. The platform aggregates data items by (asset, dataType=rating, source); each subsequent record from the same source overwrites the agency's previous snapshot. Multi-agency aggregation falls out naturally — different agencies (moodys, sp, fitch, dbrs, …) contribute distinct (asset, dataType=rating, source) rows. Agencies that publish multiple ratings for the same asset (e.g. long-term + short-term + outlook) ship them all in one snapshot via the `values` map keyed by semantic rating type. Classification metadata describing the rated instrument is carried at snapshot level since it applies to the asset, not to individual rating dimensions.",
+  "description": "A snapshot of credit-rating observations for a single asset from a single rating agency. The platform aggregates data items by (asset, dataType=rating, source); each subsequent record from the same source overwrites the agency's previous snapshot. Multi-agency aggregation falls out naturally — different agencies (moodys, sp, fitch, dbrs, …) contribute distinct (asset, dataType=rating, source) rows. Agencies that publish multiple ratings for the same asset (e.g. long-term + short-term + outlook) ship them all in one snapshot via the `values` map keyed by semantic rating type. Asset-level identifiers and instrument classification metadata are carried at snapshot level since they describe the asset, not individual rating dimensions. Field shape and vocabulary follow the Moody's RMC data model and are reused by other agencies where applicable.",
   "type": "object",
   "required": ["timestamp", "values"],
   "properties": {
     "timestamp": {
       "type": "integer",
       "description": "Producer timestamp at which the snapshot was emitted, epoch milliseconds. Used as the default for any value entry that omits its own `timestamp`."
+    },
+    "debtId": {
+      "type": "string",
+      "maxLength": 50,
+      "description": "Primary identifier for the rated instrument. Priority order: CUSIP, ISIN, Moody's ID (only one identifier appears here; the rest go in `otherIdentifiers`). Examples: \"ISN:IE0004514711\", \"MDY:823482245\"."
+    },
+    "otherIdentifiers": {
+      "type": "array",
+      "items": { "type": "string", "maxLength": 50 },
+      "description": "Additional identifiers beyond the primary `debtId`. UI surfaces a \"View All\" affordance when more than one is present."
+    },
+    "fundName": {
+      "type": "string",
+      "maxLength": 255,
+      "description": "Deal name / issuer name as registered with the agency. e.g. \"BNY Mellon US Dollar Liquidity Fund\"."
+    },
+    "regulatoryDisclosures": {
+      "type": "string",
+      "maxLength": 255,
+      "description": "Regulatory disclosure text required by the agency. e.g. \"Please see www.moodys.com for the assessment announcement, copyright notice/disclaimer, additional disclosures and other terms and conditions.\""
     },
     "values": {
       "type": "object",
@@ -20,15 +40,41 @@
         "properties": {
           "grade": {
             "type": "string",
-            "description": "Raw rating value as published by the agency. Moody's long-term: Aaa…C; S&P/Fitch/DBRS long-term: AAA…D; short-term scales and outlook/watch values use each agency's own vocabulary."
+            "maxLength": 50,
+            "description": "Current rating grade as published by the agency, preserved verbatim. Moody's long-term: Aaa…C; Moody's MMF: Aaa-mf…C-mf; S&P/Fitch/DBRS long-term: AAA…D; outlook/watch use each agency's own vocabulary. (Source field: Moody's \"Current\".)"
           },
           "scale": {
             "type": "string",
-            "description": "Optional. Identifier of the agency's rating scale used for `grade` (e.g. \"moodys-long-term\", \"sp-short-term\", \"fitch-issuer-default\"). Useful when an agency publishes multiple scales under the same rating type."
+            "description": "Optional. Identifier of the agency's rating scale used for `grade` (e.g. \"moodys-long-term\", \"moodys-mmf\", \"sp-short-term\", \"fitch-issuer-default\"). Useful when an agency publishes multiple scales under the same rating type."
+          },
+          "class": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Rating class value. The agency surfaces only credit ratings here, filtering out non-credit rating classes. e.g. \"Backed LT Mutual Fund (Foreign Currency)\"."
+          },
+          "classDescription": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Rating class description (issuer tab) or security class description (debt tab). e.g. \"MONEY MARKET FUND\". (Source field: Moody's \"Description\".)"
           },
           "timestamp": {
             "type": "integer",
-            "description": "Optional. Per-value timestamp in epoch milliseconds. Falls back to the snapshot's top-level `timestamp` if absent."
+            "description": "Optional. Latest credit-rating date for this observation, including watch and confirmation, in epoch milliseconds. Falls back to the snapshot's top-level `timestamp` if absent. (Source field: Moody's \"Date\".)"
+          },
+          "action": {
+            "type": "string",
+            "maxLength": 50,
+            "description": "Word(s) describing the rating direction or event. e.g. \"New\", \"Change in Scale\", \"Affirmed\", \"Upgrade\", \"Downgrade\"."
+          },
+          "supportingEntity": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Third party that acts as a guarantor for this specific rating (e.g. mutual fund advisor). Per-rating equivalent of the asset-level `classification.enhancements`. (Source field: Moody's \"Supporting_entity\".)"
+          },
+          "supportTypeDescription": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Description of the supporting entity's role. e.g. \"Mutual Fund Advisor\". (Source field: Moody's \"Support_type_description\".)"
           },
           "signature": {
             "type": "string",
@@ -39,37 +85,32 @@
     },
     "classification": {
       "type": "object",
-      "description": "Optional metadata describing the rated instrument. Carried at snapshot level since these attributes describe the asset, not individual rating dimensions. Fields mirror the Moody's classification taxonomy and are reused by other agencies where applicable.",
+      "description": "Optional asset-level instrument classification metadata. Carried at snapshot level since these attributes describe the asset, not individual rating dimensions. Field shape follows the Moody's classification taxonomy and is reused by other agencies where applicable.",
       "properties": {
         "securityClass": {
           "type": "string",
           "maxLength": 50,
-          "description": "Security class (e.g. \"Mutual Fund (MMK)\")."
+          "description": "Type of instrument based on a broad grouping. e.g. \"Mutual Fund (MMK)\"."
         },
         "instrumentType": {
           "type": "string",
           "maxLength": 50,
-          "description": "Instrument type (e.g. \"Money Market Fund\", \"Bond Fund\")."
+          "description": "Description of the category or class of the equity/debt issuance. e.g. \"Money Market Fund\", \"Bond Fund\"."
         },
         "privatePlacement": {
           "type": "string",
           "maxLength": 50,
-          "description": "Private placement indicator (e.g. \"Yes\", \"Not Applicable\")."
+          "description": "Indicates whether the instrument is at least partially made available to pre-selected investors instead of by way of a public issue (includes 144A). e.g. \"Yes\", \"Not Applicable\"."
         },
         "enhancements": {
           "type": "string",
           "maxLength": 255,
-          "description": "Credit enhancements or advisor name."
+          "description": "Asset-level credit enhancement / advisor name. Per-rating support attribution is carried under the rating's `supportingEntity` / `supportTypeDescription`."
         },
         "equityEvents": {
           "type": "string",
           "maxLength": 255,
-          "description": "Equity-related events (e.g. fund inception date)."
-        },
-        "fundName": {
-          "type": "string",
-          "maxLength": 255,
-          "description": "Fund or instrument name as registered with the agency."
+          "description": "Date or descriptor of when the fund becomes active / is launched / first trades (e.g. mutual fund inception date)."
         }
       }
     }

--- a/schemas/data/rating.schema.json
+++ b/schemas/data/rating.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ownera.io/certificates/data/rating.schema.json",
+  "title": "Rating",
+  "description": "A snapshot of credit-rating observations for a single asset from a single rating agency. The platform aggregates data items by (asset, dataType=rating, source); each subsequent record from the same source overwrites the agency's previous snapshot. Multi-agency aggregation falls out naturally — different agencies (moodys, sp, fitch, dbrs, …) contribute distinct (asset, dataType=rating, source) rows. Agencies that publish multiple ratings for the same asset (e.g. long-term + short-term + outlook) ship them all in one snapshot via the `values` map keyed by semantic rating type. Classification metadata describing the rated instrument is carried at snapshot level since it applies to the asset, not to individual rating dimensions.",
+  "type": "object",
+  "required": ["timestamp", "values"],
+  "properties": {
+    "timestamp": {
+      "type": "integer",
+      "description": "Producer timestamp at which the snapshot was emitted, epoch milliseconds. Used as the default for any value entry that omits its own `timestamp`."
+    },
+    "values": {
+      "type": "object",
+      "minProperties": 1,
+      "description": "Map of ratingType → observation. Keys are semantic rating names so consumers can look up a known rating dimension across agencies. Expected vocabulary: \"longTerm\", \"shortTerm\", \"mmf\" (money-market-fund rating), \"fundCredit\", \"issuer\", \"issue\" (rated instrument vs rated entity), \"counterparty\"; \"outlook\" (Stable/Positive/Negative/Developing); \"watch\" (Negative/Positive/Evolving). Grade values are preserved verbatim from each agency — no cross-agency normalization on our side. New keys may be added as use cases arise; consumers should ignore unrecognised keys.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["grade"],
+        "properties": {
+          "grade": {
+            "type": "string",
+            "description": "Raw rating value as published by the agency. Moody's long-term: Aaa…C; S&P/Fitch/DBRS long-term: AAA…D; short-term scales and outlook/watch values use each agency's own vocabulary."
+          },
+          "scale": {
+            "type": "string",
+            "description": "Optional. Identifier of the agency's rating scale used for `grade` (e.g. \"moodys-long-term\", \"sp-short-term\", \"fitch-issuer-default\"). Useful when an agency publishes multiple scales under the same rating type."
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "Optional. Per-value timestamp in epoch milliseconds. Falls back to the snapshot's top-level `timestamp` if absent."
+          },
+          "signature": {
+            "type": "string",
+            "description": "Optional. DER-encoded signature over the observation, when the producer is a signing oracle. Passed through verbatim for downstream verification."
+          }
+        }
+      }
+    },
+    "classification": {
+      "type": "object",
+      "description": "Optional metadata describing the rated instrument. Carried at snapshot level since these attributes describe the asset, not individual rating dimensions. Fields mirror the Moody's classification taxonomy and are reused by other agencies where applicable.",
+      "properties": {
+        "securityClass": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Security class (e.g. \"Mutual Fund (MMK)\")."
+        },
+        "instrumentType": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Instrument type (e.g. \"Money Market Fund\", \"Bond Fund\")."
+        },
+        "privatePlacement": {
+          "type": "string",
+          "maxLength": 50,
+          "description": "Private placement indicator (e.g. \"Yes\", \"Not Applicable\")."
+        },
+        "enhancements": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Credit enhancements or advisor name."
+        },
+        "equityEvents": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Equity-related events (e.g. fund inception date)."
+        },
+        "fundName": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Fund or instrument name as registered with the agency."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `schemas/data/rating.schema.json` 
- One snapshot per `(asset, dataType=rating, source)`; agencies (moodys, SNP, fitch, dbrs, …) are distinct `source` rows aggregated by the platform.
- `values` map keyed by rating type (`longTerm`, `shortTerm`, `mmf`, `outlook`, `watch`, …) so a single agency can publish multiple rating dimensions in one record.
- Grades preserved verbatim per agency — no cross-agency normalization on our side. UI consumes raw values (see roadmap#1224 / #1225 for display rules).
- `classification` block carries the 6 instrument-metadata fields (security class, instrument type, private placement, enhancements, equity events, fund name) at snapshot level since they describe the asset, not individual rating dimensions.

## Why here, not template-catalog

Schemas live in this repo alongside `pricing.schema.json`. The chart-side provider plugin and the adapter template will re-land once this schema is the source of truth.

## Refs

- Feature ticket: owneraio/roadmap#1217
- UI tickets: owneraio/roadmap#1224, owneraio/roadmap#1225

## Test plan

- [ ] JSON linter workflow (this repo) passes.
- [ ] Spec consumers (data-adapters Moody's plugin, OSS dataItems renderers) validate sample payloads against the published schema URL once it lands.
- [ ] Sample multi-agency payload (Moody's `longTerm`+`mmf`, S&P `longTerm`) round-trips cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)