### PR TITLE
schema(assetHeader): add optional documents array

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -56,6 +56,43 @@
         }
       },
       "required": ["type", "value"]
+    },
+    "document": {
+      "type": "object",
+      "description": "A document attached to the asset (prospectus, term sheet, factsheet, KID/KIID, certificate, etc.), uploaded to the router's file storage via the data-documents endpoint and retrievable by its URI. Distinct from referenceData's *Url fields, which are external web links rather than stored, hash-verified artifacts.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["prospectus", "termSheet", "factsheet", "kid", "kiid", "annualReport", "offeringMemorandum", "certificate", "other"],
+          "description": "Semantic document type so consumers can label/route it. Use \"other\" when none fit; free-text intent goes in `title`."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable label for the document (e.g. \"Series A Term Sheet\"). Optional."
+        },
+        "uri": {
+          "type": "string",
+          "description": "Relative URI to retrieve the document (the fileURI returned by the data-documents upload; fetched via GET /docs/{uri}). Not an external http(s) URL."
+        },
+        "hash": {
+          "type": "string",
+          "description": "base64-encoded sha3-256 of the document bytes, for integrity verification."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The document's MIME type (e.g. \"application/pdf\")."
+        },
+        "fileName": {
+          "type": "string",
+          "description": "The document's file name."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The document size in bytes."
+        }
+      },
+      "required": ["type", "uri"]
     }
   },
   "properties": {
@@ -99,6 +136,11 @@
       "type": "array",
       "description": "Identifiers other than the primary one carried in the ingest envelope (ISIN, CUSIP, FIGI, DTI, LEI, etc.)",
       "items": { "$ref": "#/definitions/additionalIdentifier" }
+    },
+    "documents": {
+      "type": "array",
+      "description": "Documents attached to the asset (prospectus, term sheet, certificates…), uploaded via the data-documents endpoint. Each item carries a stored-file URI plus integrity metadata.",
+      "items": { "$ref": "#/definitions/document" }
     }
   },
   "required": ["name", "category"]

--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -59,16 +59,11 @@
     },
     "document": {
       "type": "object",
-      "description": "A document attached to the asset (prospectus, term sheet, factsheet, KID/KIID, certificate, etc.), uploaded to the router's file storage via the data-documents endpoint and retrievable by its URI. Distinct from referenceData's *Url fields, which are external web links rather than stored, hash-verified artifacts.",
+      "description": "A document attached to the asset, uploaded to the router's file storage via the data-documents endpoint and retrievable by its URI. The binary lives in file storage; this reference travels inside the ingested data item.",
       "properties": {
-        "type": {
+        "id": {
           "type": "string",
-          "enum": ["prospectus", "termSheet", "factsheet", "kid", "kiid", "annualReport", "offeringMemorandum", "certificate", "other"],
-          "description": "Semantic document type so consumers can label/route it. Use \"other\" when none fit; free-text intent goes in `title`."
-        },
-        "title": {
-          "type": "string",
-          "description": "Human-readable label for the document (e.g. \"Series A Term Sheet\"). Optional."
+          "description": "Document id."
         },
         "uri": {
           "type": "string",
@@ -92,7 +87,7 @@
           "description": "The document size in bytes."
         }
       },
-      "required": ["type", "uri"]
+      "required": ["id", "uri"]
     }
   },
   "properties": {
@@ -139,7 +134,7 @@
     },
     "documents": {
       "type": "array",
-      "description": "Documents attached to the asset (prospectus, term sheet, certificates…), uploaded via the data-documents endpoint. Each item carries a stored-file URI plus integrity metadata.",
+      "description": "Documents attached to the asset, uploaded via the data-documents endpoint. Each item carries a stored-file URI plus integrity metadata.",
       "items": { "$ref": "#/definitions/document" }
     }
   },


### PR DESCRIPTION
Adds an optional `documents` array (+ `document` definition) to `assetHeader.schema.json` for asset-attached files uploaded via the data-documents endpoint.

Related to https://github.com/owneraio/finp2p-core/issues/2375

🤖 Generated with [Claude Code](https://claude.com/claude-code)