### PR TITLE
schema(assetHeader): relax icon to uri-reference

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -109,8 +109,8 @@
     },
     "icon": {
       "type": "string",
-      "format": "uri",
-      "description": "URL to asset icon image"
+      "format": "uri-reference",
+      "description": "Asset icon image. Either an absolute URL or a relative fileURI returned by the data-documents upload (e.g. \"dataprovider/data/<uuid>\")."
     },
     "currency": {
       "type": "string",


### PR DESCRIPTION
Changes `assetHeader.icon` from `format: uri` to `format: uri-reference`.

Icons uploaded via the data-documents endpoint are referenced by a relative fileURI (`dataprovider/data/<uuid>`), which has no scheme and so fails `format: uri` validation on ingest (`icon: Does not match format 'uri'`). `uri-reference` still validates URI syntax but allows relative references (absolute URLs remain valid).

Related to https://github.com/owneraio/finp2p-core/issues/2375

🤖 Generated with [Claude Code](https://claude.com/claude-code)