### PR TITLE
schemas(assetHeader): URI-typed profileImage, bannerImage + documents migration (roadmap#1291)

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -56,38 +56,6 @@
         }
       },
       "required": ["type", "value"]
-    },
-    "document": {
-      "type": "object",
-      "description": "A document attached to the asset, uploaded to the router's file storage via the data-documents endpoint and retrievable by its URI. The binary lives in file storage; this reference travels inside the ingested data item.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Document id."
-        },
-        "uri": {
-          "type": "string",
-          "description": "Relative URI to retrieve the document (the fileURI returned by the data-documents upload; fetched via GET /docs/{uri}). Not an external http(s) URL."
-        },
-        "hash": {
-          "type": "string",
-          "description": "base64-encoded sha3-256 of the document bytes, for integrity verification."
-        },
-        "mimeType": {
-          "type": "string",
-          "description": "The document's MIME type (e.g. \"application/pdf\")."
-        },
-        "fileName": {
-          "type": "string",
-          "description": "The document's file name."
-        },
-        "size": {
-          "type": "integer",
-          "format": "int64",
-          "description": "The document size in bytes."
-        }
-      },
-      "required": ["id", "uri"]
     }
   },
   "properties": {
@@ -112,6 +80,16 @@
       "format": "uri-reference",
       "description": "Asset icon image. Either an absolute URL or a relative fileURI returned by the data-documents upload (e.g. \"dataprovider/data/<uuid>\")."
     },
+    "profileImage": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI to the asset's profile picture. Router-fetched as a file via the URI-typed file-detection rule (roadmap#1291)."
+    },
+    "bannerImage": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI to the asset's banner image. Router-fetched as a file via the URI-typed file-detection rule (roadmap#1291)."
+    },
     "currency": {
       "type": "string",
       "pattern": "^[A-Z]{3}$",
@@ -134,8 +112,11 @@
     },
     "documents": {
       "type": "array",
-      "description": "Documents attached to the asset, uploaded via the data-documents endpoint. Each item carries a stored-file URI plus integrity metadata.",
-      "items": { "$ref": "#/definitions/document" }
+      "description": "URIs of documents attached to the asset. Each item is a URI resolved by the router's file-fetch process under the URI-typed file-detection rule (roadmap#1291). Router fetches every entry; document metadata (hash, mimeType, fileName, size) is looked up separately via the data-documents endpoint.",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
     }
   },
   "required": ["name", "category"]


### PR DESCRIPTION
Roadmap parent: **owneraio/roadmap#1291** — Replace name-based `documents` file heuristic with explicit schema-level marker.

## What this changes on `schemas/data/assetHeader.schema.json`

**Added — two new URI-typed image fields**

- `profileImage` — `string` / `format: uri` — the asset's profile picture.
- `bannerImage` — `string` / `format: uri` — the asset's banner image.

Both participate in the router's URI-typed file-detection rule (#1291 FR-2) — the router walks the payload, sees a URI-typed field, and runs the file-fetch process automatically. This lands the "at least one non-`documents` URI-typed field in a real schema" requirement (#1291 FR-5).

**Migrated — `documents` field**

- Was: `array` of file-shaped objects (`{ id, uri, hash, mimeType, fileName, size }`) via `$ref: #/definitions/document`.
- Now: `array` of URI strings (`type: string, format: uri`).

Router still fetches every entry; document metadata (hash, mimeType, fileName, size) moves out of the payload and is looked up separately via the data-documents endpoint per the new contract (#1291 FR-3).

**Removed — `document` definition** in `definitions/`. No references remain after the `documents` migration.

## Not touched

- `kycRequirements.schema.json` also emits a `documents` array (per #1291 FR-3) — deliberately left for a follow-up PR to keep this diff focused on the asset header change.
- README + `dataEnvelope.schema.json` note describing the URI-typed rule (#1291 FR-4 / FR-8) — separate documentation PR.
- Router-side implementation of the type-based detection — #1291 platform task, different repo.

## Why `format: "uri"` (not `uri-reference`)

Matching #1291's stated recommendation ("start with `format: \"uri\"`") in the open questions section. The existing `icon` field on this schema uses `uri-reference` (allows relative fileURIs). If #1291 resolves in favour of `uri-reference` we adjust in a follow-up — both fields are new so no back-compat cost.

## Back-compat

`documents` wire shape changes from `[ { id, uri, ... } ]` to `[ "uri-string" ]`. Coordinate this with router flag `ROUTER_URI_FILE_DETECTION` (#1291) so partners don't hit dual-format flip-flops.

## Diff

```
schemas/data/assetHeader.schema.json | 49 +++++++++++-------------------------
1 file changed, 15 insertions(+), 34 deletions(-)
```

Closes toward #1291 (asset-header portion only; kyc + docs follow-ups still open).