### PR TITLE
[FIX]: Deleting constraints for currency

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -107,8 +107,7 @@
     },
     "currency": {
       "type": "string",
-      "pattern": "^[A-Z]{3}$",
-      "description": "Denomination / settlement currency (ISO 4217)."
+      "description": "Denomination / settlement currency"
     },
     "issuingOrg": {
       "type": "object",

--- a/schemas/data/pricing.schema.json
+++ b/schemas/data/pricing.schema.json
@@ -8,8 +8,7 @@
   "properties": {
     "currency": {
       "type": "string",
-      "pattern": "^[A-Z]{3}$",
-      "description": "Denomination currency for the snapshot (ISO 4217)."
+      "description": "Denomination currency for the snapshot."
     },
     "timestamp": {
       "type": "integer",


### PR DESCRIPTION
**Problem**: we have a constraint for the currency `pattern": "^[A-Z]{3}$"` and `(ISO 4217)` mention in the descriotion, but the currency could be represented by crypto which is not supported by `(ISO 4217)`

**Solution:** no constraints for currencu