### PR TITLE
schemas(data): add currencyRating schema

### DIFF
--- a/schemas/data/currencyRating.schema.json
+++ b/schemas/data/currencyRating.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ownera.io/certificates/data/currencyRating.schema.json",
+  "title": "CurrencyRating",
+  "description": "A snapshot of foreign-exchange rates for a single asset. The asset's own currency is the base; each entry in `rates` gives the exchange rate from that base to a target currency. Example: for an asset denominated in USD, `rates` may contain `{ currencyId: \"EUR\", rate: 2.2 }`, `{ currencyId: \"CAD\", rate: 1.1 }`.",
+  "type": "object",
+  "required": ["updateId", "timestamp", "rates"],
+  "properties": {
+    "updateId": {
+      "type": "string",
+      "description": "Unique identifier for this rate-snapshot update."
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Producer timestamp at which the snapshot was emitted, epoch milliseconds."
+    },
+    "rates": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Array of {currencyId, rate} pairs — FX rate from the asset's currency to each listed target currency.",
+      "items": {
+        "type": "object",
+        "required": ["currencyId", "rate"],
+        "properties": {
+          "currencyId": {
+            "type": "string",
+            "description": "Target currency identifier. e.g. \"EUR\", \"CAD\"."
+          },
+          "rate": {
+            "type": "number",
+            "description": "Exchange rate from the asset's currency to `currencyId`."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/data/currencyRating.schema.json
+++ b/schemas/data/currencyRating.schema.json
@@ -4,11 +4,11 @@
   "title": "CurrencyRating",
   "description": "A snapshot of foreign-exchange rates for a single asset. The asset's own currency is the base; each entry in `rates` gives the exchange rate from that base to a target currency. Example: for an asset denominated in USD, `rates` may contain `{ currencyId: \"EUR\", rate: 2.2 }`, `{ currencyId: \"CAD\", rate: 1.1 }`.",
   "type": "object",
-  "required": ["updateId", "timestamp", "rates"],
+  "required": ["quoteId", "timestamp", "rates"],
   "properties": {
-    "updateId": {
+    "quoteId": {
       "type": "string",
-      "description": "Unique identifier for this rate-snapshot update."
+      "description": "Unique identifier for this FX-quote snapshot."
     },
     "timestamp": {
       "type": "integer",


### PR DESCRIPTION
## Summary

Adds `schemas/data/currencyRating.schema.json` — a snapshot of foreign-exchange rates for a single asset.

The asset's own currency is the base; each entry in `rates` gives the FX rate from that base to a target currency. Example: for an asset denominated in USD, `rates` may contain `{ currencyId: "EUR", rate: 2.2 }`, `{ currencyId: "CAD", rate: 1.1 }`.

## Shape

| Field | Type | Required | Notes |
|---|---|---|---|
| `quoteId` | string | ✓ | Unique identifier for this FX-quote snapshot |
| `timestamp` | integer | ✓ | Epoch ms |
| `rates` | array | ✓ | `minItems: 1`; items = `{ currencyId: string, rate: number }` |

## Test plan

- [ ] JSON syntax lint passes.
- [ ] Confirm array-of-pairs shape is desired vs. a `values` map (existing pricing/rating schemas use maps).
- [ ] Confirm no additional constraint on `currencyId` (e.g. ISO 4217 restriction) is required.

## Refs

Follow-on to schemas work landed in #29 (epic owneraio/roadmap#1236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)