### PR TITLE
schema(assetHeader): make currency (denomination) optional

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -127,7 +127,8 @@
     },
     "currency": {
       "type": "string",
-      "description": "Denomination / settlement currency"
+      "pattern": "^[A-Z]{3}$",
+      "description": "Denomination / settlement currency (ISO 4217). Optional: not every asset class has a meaningful denomination, and catalog identity must not depend on valuation data — consumers that value holdings must treat a missing currency like a missing FX rate (exclude and surface, do not guess)."
     },
     "issuingOrg": {
       "type": "object",
@@ -193,5 +194,5 @@
       "items": { "$ref": "#/definitions/assetPublicInfoItem" }
     }
   },
-  "required": ["name", "symbol", "assetClass", "currency"]
+  "required": ["name", "symbol", "assetClass"]
 }


### PR DESCRIPTION
## Problem

`currency` is in `required`, so an assetHeader without it is rejected wholesale at router ingest — the instrument gets **no identity at all** in the data layer (no name/symbol/class), even though only the valuation path needs a denomination.

Hit in practice on STG: the Ownera Asset Catalog store doesn't model currency on its records, so all 26 of its assetHeaders were rejected every poll cycle and the app's catalog surfaced zero instruments (Browse Catalog permanently disabled).

## Why not fix it elsewhere

- **Default the value in the connector** (owneraio/data-adapters#10): rejected — a deployment-wide default silently stamps a possibly-wrong denomination, corrupting FX conversions downstream. Silently wrong loses to visibly absent.
- **Backfill the store**: right for records whose denomination is known, but doesn't resolve the structural coupling — any future catalog/asset-class without a meaningful denomination hits the same wall (#22 made exactly this cross-asset-class argument before the epic #1236 realignment re-tightened it, apparently without revisiting that decision).

## Change

- `required`: `[name, symbol, assetClass]` — identity fields only (`symbol`/`assetClass` stay required; they're derivable by any producer)
- `currency` stays as an optional property, now with the `^[A-Z]{3}$` ISO-4217 pattern so present-but-malformed values are still rejected
- Description documents the consumer contract: treat missing currency like a missing FX rate — exclude from valuation and surface it, never guess

## Consumers

The treasury/portfolio valuation path already has the graceful-degradation machinery (`fxAvailable` / `missingRateCurrencies` warning); a missing denomination lands in the same bucket. Catalog/browse/onboarding flows don't consume currency for identity.

Follow-up once merged (S3 sync publishes on master): owneraio/data-adapters mapper stops skipping headers that lack currency (one-line revert of the skip guard added in #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)