### PR TITLE
schema(assetHeader): drop the ISO-4217 pattern from `currency`

### DIFF
--- a/schemas/data/assetHeader.schema.json
+++ b/schemas/data/assetHeader.schema.json
@@ -127,8 +127,7 @@
     },
     "currency": {
       "type": "string",
-      "pattern": "^[A-Z]{3}$",
-      "description": "Denomination / settlement currency (ISO 4217). Optional: not every asset class has a meaningful denomination, and catalog identity must not depend on valuation data — consumers that value holdings must treat a missing currency like a missing FX rate (exclude and surface, do not guess)."
+      "description": "Denomination / settlement currency — an ISO 4217 code (`USD`) or a digital-asset code (`USDC`, `USDT`), so deliberately not constrained to three letters. Optional: not every asset class has a meaningful denomination, and catalog identity must not depend on valuation data — consumers that value holdings must treat a missing currency like a missing FX rate (exclude and surface, do not guess)."
     },
     "issuingOrg": {
       "type": "object",


### PR DESCRIPTION
#35 added `pattern: ^[A-Z]{3}$` to `currency`. That rejects every digital-asset denomination — USDC, USDT, EURC are all four characters — so a Tokenized Cash instrument denominated in a stablecoin can no longer be ingested at all:

  currency "USDC" -> rejected, code 4000
      "General validation error, validation errors:
       currency: Does not match pattern '^[A-Z]{3}$'"
  currency "USD"  -> accepted

(Verified on local6 against release-v0.28 with two ingests identical apart from that one field.)

#31 had removed this constraint deliberately, for exactly this reason. #35 reinstated it alongside an unrelated and good change — making `currency` optional — so the reinstatement looks incidental rather than intended.

`pricing.schema.json` in this same repo already declares `currency` as a plain string with no pattern, for the same concept. As it stands a price snapshot may be denominated in USDC while the instrument it prices may not.

The description keeps #35's guidance about the field being optional and about consumers not guessing a missing denomination — that part is unaffected — and now states what the field actually accepts, so it no longer promises ISO 4217 while holding stablecoin codes.

Impact: this currently blocks all open PRs in ownera-apps, which fail CI on the two Tokenized Cash creation specs.