### PR TITLE
feat(user-schemas): add LEI to company_info; relax required fields; drop payments-legacy fields

### DIFF
--- a/schemas/user/company_info.schema.json
+++ b/schemas/user/company_info.schema.json
@@ -112,16 +112,15 @@
     "businessRegistrationId": {
       "$ref": "#/definitions/businessRegistrationId"
     },
+    "lei": {
+      "description": "Legal Entity Identifier (ISO 17442) of the company",
+      "type": "string",
+      "pattern": "^[A-Z0-9]{18}[0-9]{2}$"
+    },
     "beneficialOwners": {
       "description": "List of beneficial owners",
       "type": "array",
       "items": { "$ref": "#/definitions/beneficialOwner" }
-    },
-    "industryCode": {
-      "description": "Merchant category codes (MCC)",
-      "type": "string",
-      "maxLength": 4,
-      "pattern": "^[0-9]{4}$"
     },
     "vatNumber": {
       "description": "VAT number",
@@ -134,18 +133,10 @@
       "type": "string",
       "maxLength": 100,
       "minLength": 1
-    },
-    "statementDescriptor": {
-      "description": "Statement descriptor explains charges or payments on customer's bank statements",
-      "type": "string",
-      "minLength": 5,
-      "maxLength": 22,
-      "pattern": "^[^<>,'\"*]*$"
     }
   },
   "required": [
     "legalBusinessName",
-    "businessRegisteredCountry",
-    "beneficialOwners"
+    "businessRegisteredCountry"
   ]
 }

--- a/schemas/user/individual_info.schema.json
+++ b/schemas/user/individual_info.schema.json
@@ -57,5 +57,5 @@
     },
     "address": { "$ref": "#/definitions/address" }
   },
-  "required": ["name", "email", "address"]
+  "required": ["name", "address"]
 }


### PR DESCRIPTION
Driven by the Investor Management & Creation UX refresh — owneraio/roadmap#1353 (design mock linked there).

## Changes

### `schemas/user/company_info.schema.json`
- **Add optional `lei`** — Legal Entity Identifier (ISO 17442), pattern `^[A-Z0-9]{18}[0-9]{2}$`. LEI previously existed only on the asset/issuer side (`assetHeader`, `referenceData`); institutional investors need it as a first-class identifier.
- **Remove `beneficialOwners` from `required`** — bank-managed quick-create (ops desk creates the investor, no investor login) captures no contact person; a company certificate must still be valid.
- **Remove `industryCode` (MCC) and `statementDescriptor`** — card-payments concepts (merchant category codes, cardholder statement text) with no role in institutional asset workflows. `additionalProperties` remains allowed, so existing certificates carrying these fields stay valid; they are simply no longer part of the contract.

### `schemas/user/individual_info.schema.json`
- **Remove `email` from `required`** — bank-managed individual accounts have no investor login/email. `name` and `address` (country) remain required.

## Compatibility
All changes are relaxations or additive: every certificate valid before this PR remains valid after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)